### PR TITLE
Fix link hint display

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,13 +210,14 @@
 
                                 // 情報源へのリンク表示(リンクがある場合のみ)
                                 if (targetUrl) {
-                                    contentHtml += `<div class="text-indigo-600 text-sm mt-3 font-medium">情報源を開く <span aria-hidden="true">&rarr;</span></div>`;
+                                    contentHtml += `<a href="${escapeHtml(targetUrl)}" target="_blank" rel="noopener noreferrer" class="text-indigo-600 text-sm mt-3 font-medium">情報源を開く <span aria-hidden="true">&rarr;</span></a>`;
                                 }
 
                                 newsCard.innerHTML = contentHtml;
 
                                 if (targetUrl) {
-                                    newsCard.addEventListener('click', () => {
+                                    newsCard.addEventListener('click', (e) => {
+                                        if (e.target.closest('a')) return; // リンククリック時はカードの処理をスキップ
                                         window.open(targetUrl, '_blank', 'noopener,noreferrer');
                                     });
                                     newsCard.style.cursor = 'pointer'; // クリック可能なことを示す

--- a/index.html
+++ b/index.html
@@ -187,6 +187,16 @@
                                 const date = escapeHtml(newsData.date);
                                 const source = escapeHtml(newsData.source);
                                 
+                                // リンクとして利用できるURLを決定
+                                let targetUrl = null;
+                                if (newsData.url && isValidUrl(newsData.url)) {
+                                    // 有効なURLフィールドを使用
+                                    targetUrl = newsData.url;
+                                } else if (newsData.source && isValidDomain(newsData.source)) {
+                                    // フォールバック: ドメイン名からURLを構築（ドメイン名が有効な場合のみ）
+                                    targetUrl = `https://${newsData.source}`;
+                                }
+
                                 let contentHtml = `<h2 class="text-xl font-semibold text-indigo-700 mb-2">${title}</h2>`;
                                 if (summary) {
                                     contentHtml += `<p class="text-gray-700 mb-3 text-sm leading-relaxed">${summary}</p>`;
@@ -197,25 +207,14 @@
                                 if (source) {
                                     contentHtml += `<span class="source-tag">${source}</span>`;
                                 }
-                                
-                                // 情報源へのリンク表示
-                                if (source) {
+
+                                // 情報源へのリンク表示(リンクがある場合のみ)
+                                if (targetUrl) {
                                     contentHtml += `<div class="text-indigo-600 text-sm mt-3 font-medium">情報源を開く <span aria-hidden="true">&rarr;</span></div>`;
                                 }
-                                
+
                                 newsCard.innerHTML = contentHtml;
-                                
-                                // URLの検証とカード全体にクリックイベントを追加
-                                let targetUrl = null;
-                                
-                                if (newsData.url && isValidUrl(newsData.url)) {
-                                    // 有効なURLフィールドを使用
-                                    targetUrl = newsData.url;
-                                } else if (newsData.source && isValidDomain(newsData.source)) {
-                                    // フォールバック: ドメイン名からURLを構築（ドメイン名が有効な場合のみ）
-                                    targetUrl = `https://${newsData.source}`;
-                                }
-                                
+
                                 if (targetUrl) {
                                     newsCard.addEventListener('click', () => {
                                         window.open(targetUrl, '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## Summary
- only show source link hint when a valid URL is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fba1c3240832b9f0ed7e3530877f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
  - ニュースカードのクリック可能なURL判定ロジックを整理し、リンク表示やクリック動作が一貫して有効なURLに基づくよう改善しました。
  - 「情報源を開く」リンクインジケーターの表示条件が、適切なURLの存在時のみとなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->