### PR TITLE
Fix timeout destruction in workflow

### DIFF
--- a/.github/workflows/fetch-ai-news.yml
+++ b/.github/workflows/fetch-ai-news.yml
@@ -125,7 +125,7 @@ jobs:
 
               // タイムアウト設定
               req.setTimeout(120000, () => {
-                req.abort();
+                req.destroy(new Error('timeout'));
                 reject(new Error('API request timed out after 120 seconds'));
               });
 

--- a/.github/workflows/fetch-ai-news.yml
+++ b/.github/workflows/fetch-ai-news.yml
@@ -117,7 +117,10 @@ jobs:
                 });
               });
 
+              let timedOut = false;
+
               req.on('error', (error) => {
+                if (timedOut) return;
                 console.error('Network error during API request:', error);
                 // エラーメッセージにAPIキーが含まれないように注意
                 reject(new Error('Network error during API request'));
@@ -125,6 +128,7 @@ jobs:
 
               // タイムアウト設定
               req.setTimeout(120000, () => {
+                timedOut = true;
                 req.destroy(new Error('timeout'));
                 reject(new Error('API request timed out after 120 seconds'));
               });


### PR DESCRIPTION
## Summary
- update timeout handler in workflow to use `req.destroy` instead of `req.abort`

## Testing
- `grep -n timeout -n .github/workflows/fetch-ai-news.yml`

------
https://chatgpt.com/codex/tasks/task_e_683fdabd9934832b9e9c6117108485d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ニュース取得ワークフローにおけるタイムアウト時のエラーハンドリングが改善され、より明確なエラーメッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->