### PR TITLE
Improve validation in fetch-ai-news workflow

### DIFF
--- a/.github/workflows/fetch-ai-news.yml
+++ b/.github/workflows/fetch-ai-news.yml
@@ -244,7 +244,6 @@ jobs:
               }
               
               newsData.summary = summaryLines.join(' ');
-              
               // フォールバック処理
               if (!newsData.title && lines.length > 0) {
                 newsData.title = sanitizeString(lines[0]);
@@ -336,11 +335,15 @@ jobs:
                 }
               }
               
-              // タイトルが存在し、かつ最低限の長さがある場合のみ追加
-              if (newsData.title && newsData.title.length >= 3) {
+              // タイトル・要約・情報源の妥当性を確認
+              const hasValidSource = (newsData.url && isValidUrl(newsData.url)) ||
+                                     (newsData.source && isValidDomain(newsData.source));
+              if (newsData.title && newsData.title.length >= 3 &&
+                  newsData.summary && newsData.summary.length > 0 &&
+                  hasValidSource) {
                 parsedItems.push(newsData);
               } else {
-                console.log(`Skipping news item with invalid title: "${newsData.title}"`);
+                console.log(`Skipping news item with insufficient data: "${newsData.title}"`);
               }
             }
             


### PR DESCRIPTION
## Summary
- refine `parseNewsItems` to require a valid source with URL or domain
- remove summary phrase skipping logic per feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fdb0c3860832b81db0eb756ad235c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ニュース項目の追加前に、タイトルだけでなく要約やソース情報も正しく検証するよう改善されました。
  - 不十分なデータによるスキップ時のログメッセージが、より分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->